### PR TITLE
Dash min-limit in table headers row is now 1 per column

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2039,7 +2039,7 @@ parse_table_header(
 		if (i < under_end && data[i] != '|')
 			break;
 
-		if (dashes < 3)
+		if (dashes < 1)
 			break;
 
 		i++;


### PR DESCRIPTION
Fixes #15, limit was first imposed in 35a580ffce9de1b7a80bf7f2751c6908d9fee895
