### PR TITLE
Space is required for link title

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -970,7 +970,8 @@ char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset
 		/* looking for link end: ' " ) */
 		while (i < size) {
 			if (data[i] == '\\') i += 2;
-			else if (data[i] == ')' || data[i] == '\'' || data[i] == '"') break;
+			else if (data[i] == ')') break;
+			else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}
 


### PR DESCRIPTION
In order to fix some links breaking who had title characters in them.  This also follows the markdown "spec" closer.  If you think this is a bug I can do this up for sundown instead.
