### PR TITLE
Add a flag to not put paragraphs around html tags.

### DIFF
--- a/snudown.c
+++ b/snudown.c
@@ -52,6 +52,14 @@ static const unsigned int snudown_default_md_flags =
 	MKDEXT_STRIKETHROUGH |
 	MKDEXT_TABLES;
 
+static const unsigned int snudown_wiki_md_flags =
+	MKDEXT_NO_INTRA_EMPHASIS |
+	MKDEXT_SUPERSCRIPT |
+	MKDEXT_AUTOLINK |
+	MKDEXT_STRIKETHROUGH |
+	MKDEXT_HTML_INLINE |
+	MKDEXT_TABLES;
+
 static const unsigned int snudown_default_render_flags =
 	HTML_SKIP_HTML |
 	HTML_SKIP_IMAGES |
@@ -116,8 +124,8 @@ void init_default_renderer(PyObject *module) {
 
 void init_wiki_renderer(PyObject *module) {
 	PyModule_AddIntConstant(module, "RENDERER_WIKI", RENDERER_WIKI);
-	sundown[RENDERER_WIKI].main_renderer = make_custom_renderer(&wiki_state, snudown_wiki_render_flags, snudown_default_md_flags, 0);
-	sundown[RENDERER_WIKI].toc_renderer = make_custom_renderer(&wiki_toc_state, snudown_wiki_render_flags, snudown_default_md_flags, 1);
+	sundown[RENDERER_WIKI].main_renderer = make_custom_renderer(&wiki_state, snudown_wiki_render_flags, snudown_wiki_md_flags, 0);
+	sundown[RENDERER_WIKI].toc_renderer = make_custom_renderer(&wiki_toc_state, snudown_wiki_render_flags, snudown_wiki_md_flags, 1);
 	sundown[RENDERER_WIKI].state = &wiki_state;
 	sundown[RENDERER_WIKI].toc_state = &wiki_toc_state;
 }

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -59,6 +59,7 @@ enum mkd_extensions {
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_HTML_INLINE = (1 << 9)
 };
 
 /* sd_callbacks - functions for rendering parsed data */


### PR DESCRIPTION
Basically, if you had extra line breaks you would end up with generated html like:

```
               <p><table></p>  ..... <p></table></p>
```

This flags alters the behavior of paragraph generation to end the current paragraph if an html open or close tag is hit.  
