### PR TITLE
Add support for Markdown spoiler tags

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -181,6 +181,19 @@ rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static int
+rndr_spoilerspan(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size)
+		return 0;
+
+	BUFPUTSL(ob, "<span class=\"spoiler\">");
+	bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "</span>");
+
+	return 1;
+}
+
+static int
 rndr_strikethrough(struct buf *ob, const struct buf *text, void *opaque)
 {
 	if (!text || !text->size)
@@ -717,6 +730,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 
 		NULL,
 		rndr_codespan,
+		rndr_spoilerspan,
 		rndr_double_emphasis,
 		rndr_emphasis,
 		NULL,
@@ -759,6 +773,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 
 		rndr_autolink,
 		rndr_codespan,
+		rndr_spoilerspan,
 		rndr_double_emphasis,
 		rndr_emphasis,
 		rndr_image,

--- a/html/html.c
+++ b/html/html.c
@@ -162,6 +162,15 @@ rndr_blockquote(struct buf *ob, const struct buf *text, void *opaque)
 	BUFPUTSL(ob, "</blockquote>\n");
 }
 
+static void
+rndr_blockspoiler(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (ob->size) bufputc(ob, '\n');
+	BUFPUTSL(ob, "<blockquote class=\"spoiler\">\n");
+	if (text) bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "</blockquote>\n");
+}
+
 static int
 rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 {
@@ -737,6 +746,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 	static const struct sd_callbacks cb_default = {
 		rndr_blockcode,
 		rndr_blockquote,
+		rndr_blockspoiler,
 		rndr_raw_block,
 		rndr_header,
 		rndr_hrule,

--- a/html_block_names.txt
+++ b/html_block_names.txt
@@ -23,3 +23,4 @@ style
 fieldset
 noscript
 blockquote
+span

--- a/src/html_blocks.h
+++ b/src/html_blocks.h
@@ -187,7 +187,8 @@ find_block_tag (str, len)
       "", "", "",
       "h3",
       "", "", "", "",
-      "h2"
+      "h2",
+      "span"
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1332,11 +1332,30 @@ prefix_quote(uint8_t *data, size_t size)
 	if (i < size && data[i] == ' ') i++;
 	if (i < size && data[i] == ' ') i++;
 
-	if (i < size && data[i] == '>') {
+	if ((i < size && data[i] == '>') && (i + 1 < size && data[i + 1] != '!')) {
 		if (i + 1 < size && data[i + 1] == ' ')
 			return i + 2;
 
 		return i + 1;
+	}
+
+	return 0;
+}
+
+/* prefix_blockspoiler • returns spoiler blockquote prefix length */
+static size_t
+prefix_blockspoiler(uint8_t *data, size_t size)
+{
+	size_t i = 0;
+	if (i < size && data[i] == ' ') i++;
+	if (i < size && data[i] == ' ') i++;
+	if (i < size && data[i] == ' ') i++;
+
+	if ((i < size && data[i] == '>') && (i + 1 < size && data[i + 1] == '!')) {
+		if (i + 2 < size && data[i + 2] == ' ')
+			return i + 3;
+
+		return i + 2;
 	}
 
 	return 0;
@@ -1442,6 +1461,48 @@ parse_blockquote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 	parse_block(out, rndr, work_data, work_size);
 	if (rndr->cb.blockquote)
 		rndr->cb.blockquote(ob, out, rndr->opaque);
+	rndr_popbuf(rndr, BUFFER_BLOCK);
+	return end;
+}
+
+/* parse_blockspoiler • handles parsing of a spoiler blockquote fragment */
+static size_t
+parse_blockspoiler(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+{
+	size_t beg, end = 0, pre, work_size = 0;
+	uint8_t *work_data = 0;
+	struct buf *out = 0;
+
+	out = rndr_newbuf(rndr, BUFFER_BLOCK);
+	beg = 0;
+	while (beg < size) {
+		for (end = beg + 1; end < size && data[end - 1] != '\n'; end++);
+
+		pre = prefix_blockspoiler(data + beg, end - beg);
+
+		if (pre)
+			beg += pre; /* skipping prefix */
+
+		/* empty line followed by non-quote line */
+		else if (is_empty(data + beg, end - beg) &&
+				(end >= size || (prefix_blockspoiler(data + end, size - end) == 0 &&
+				!is_empty(data + end, size - end))))
+			break;
+
+		if (beg < end) { /* copy into the in-place working buffer */
+			/* bufput(work, data + beg, end - beg); */
+			if (!work_data)
+				work_data = data + beg;
+			else if (data + beg != work_data + work_size)
+				memmove(work_data + work_size, data + beg, end - beg);
+			work_size += end - beg;
+		}
+		beg = end;
+	}
+
+	parse_block(out, rndr, work_data, work_size);
+	if (rndr->cb.blockspoiler)
+		rndr->cb.blockspoiler(ob, out, rndr->opaque);
 	rndr_popbuf(rndr, BUFFER_BLOCK);
 	return end;
 }
@@ -2255,6 +2316,9 @@ parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 		else if (prefix_quote(txt_data, end))
 			beg += parse_blockquote(ob, rndr, txt_data, end);
+
+		else if (prefix_blockspoiler(txt_data, end))
+			beg += parse_blockspoiler(ob, rndr, txt_data, end);
 
 		else if (prefix_code(txt_data, end))
 			beg += parse_blockcode(ob, rndr, txt_data, end);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -66,6 +66,7 @@ struct sd_callbacks {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(struct buf *ob, const struct buf *text, const struct buf *lang, void *opaque);
 	void (*blockquote)(struct buf *ob, const struct buf *text, void *opaque);
+	void (*blockspoiler)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*blockhtml)(struct buf *ob,const  struct buf *text, void *opaque);
 	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);
 	void (*hrule)(struct buf *ob, void *opaque);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -81,6 +81,7 @@ struct sd_callbacks {
 	/* span level callbacks - NULL or return 0 prints the span verbatim */
 	int (*autolink)(struct buf *ob, const struct buf *link, enum mkd_autolink type, void *opaque);
 	int (*codespan)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*spoilerspan)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*double_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*image)(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *alt, void *opaque);


### PR DESCRIPTION
Over on Stack Exchange, they implemented spoiler tags this way:

    >! spoiler!

Which would get rendered as:

    <blockquote class="spoiler">spoiler!</blockquote>

Built-in spoiler markdown is a popular request on reddit, and I think this'll make spoilers much nicer to use on reddit (especially on mobile). This won't support inline spoilers, though; some other syntax will need to be implemented.

In a commit to `reddit`, I committed the needed CSS.