### PR TITLE
char_superscript incorrectly handles backslashes

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1180,7 +1180,7 @@ char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 	if (data[1] == '(') {
 		sup_start = sup_len = 2;
 
-		while (sup_len < size && data[sup_len] != ')' && data[sup_len - 1] != '\\')
+		while (sup_len < size && !(data[sup_len] == ')' && data[sup_len - 1] != '\\'))
 			sup_len++;
 
 		if (sup_len == size)

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -72,6 +72,9 @@ cases = {
     r'~~normal strikethrough~~':
         '<p><del>normal strikethrough</del></p>\n',
 
+    '^((\^Grouped superscript\))':
+        '<p><sup>(^Grouped superscript)</sup></p>\n',
+
     r'\~~escaped strikethrough~~':
         '<p>~~escaped strikethrough~~</p>\n',
 


### PR DESCRIPTION
Currently, on a superscript grouping ^(like this), backslashes cause an instant end to the group, as though the first backslash seen was a closing paren. This behavior seems undesirable, and most likely unintended.

Example: `^((\^test\))` should result in `<p><sup>(^test)</sup></p>\n`, but actually results in `<p><sup>(\</sup>test))</p>`
