### PR TITLE
Fix some HAX warnings

### DIFF
--- a/html/houdini_href_e.c
+++ b/html/houdini_href_e.c
@@ -62,7 +62,9 @@ houdini_escape_href(struct buf *ob, const uint8_t *src, size_t size)
 
 	while (i < size) {
 		org = i;
-		while (i < size && HREF_SAFE[src[i]] != 0)
+		/* Skip by characters that don't need special
+		 * processing */
+		while (i < size && HREF_SAFE[src[i]] == 1)
 			i++;
 
 		if (i > org)

--- a/src/autolink.c
+++ b/src/autolink.c
@@ -51,7 +51,7 @@ sd_autolink_issafe(const uint8_t *link, size_t link_len)
 }
 
 static size_t
-autolink_delim(uint8_t *data, size_t link_end, size_t offset, size_t size)
+autolink_delim(uint8_t *data, size_t link_end, size_t max_rewind, size_t size)
 {
 	uint8_t cclose, copen = 0;
 	size_t i;
@@ -170,13 +170,13 @@ sd_autolink__www(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
 	size_t link_end;
 
-	if (offset > 0 && !ispunct(data[-1]) && !isspace(data[-1]))
+	if (max_rewind > 0 && !ispunct(data[-1]) && !isspace(data[-1]))
 		return 0;
 
 	if (size < 4 || memcmp(data, "www.", strlen("www.")) != 0)
@@ -190,7 +190,7 @@ sd_autolink__www(
 	while (link_end < size && !isspace(data[link_end]))
 		link_end++;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -206,14 +206,14 @@ sd_autolink__email(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
 	size_t link_end, rewind;
 	int nb = 0, np = 0;
 
-	for (rewind = 0; rewind < offset; ++rewind) {
+	for (rewind = 0; rewind < max_rewind; ++rewind) {
 		uint8_t c = data[-rewind - 1];
 
 		if (c == 0)
@@ -248,7 +248,7 @@ sd_autolink__email(
 	if (link_end < 2 || nb != 1 || np == 0)
 		return 0;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -264,7 +264,7 @@ sd_autolink__url(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
@@ -273,7 +273,7 @@ sd_autolink__url(
 	if (size < 4 || data[1] != '/' || data[2] != '/')
 		return 0;
 
-	while (rewind < offset && isalpha(data[-rewind - 1]))
+	while (rewind < max_rewind && isalpha(data[-rewind - 1]))
 		rewind++;
 
 	if (!sd_autolink_issafe(data - rewind, size + rewind))
@@ -293,7 +293,7 @@ sd_autolink__url(
 	while (link_end < size && !isspace(data[link_end]))
 		link_end++;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -305,7 +305,7 @@ sd_autolink__url(
 }
 
 size_t
-sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t offset, size_t size)
+sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t link_end;
 	int is_allminus = 0;
@@ -376,7 +376,7 @@ sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t
 }
 
 size_t
-sd_autolink__username(size_t *rewind_p, struct buf *link, uint8_t *data, size_t offset, size_t size)
+sd_autolink__username(size_t *rewind_p, struct buf *link, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t link_end;
 

--- a/src/html_entities.gperf
+++ b/src/html_entities.gperf
@@ -8,11 +8,33 @@
 %{
 #include <stdlib.h>
 
-// Parsers tend to choke on entities with values greater than this
+/* Parsers tend to choke on entities with values greater than this */
 const u_int32_t MAX_NUM_ENTITY_VAL = 0x10ffff;
-// Any numeric entity longer than this is obviously above MAX_ENTITY_CHAR
-// used to avoid dealing with overflows.
+/* Any numeric entity longer than this is obviously above MAX_NUM_ENTITY_VAL
+ * used to avoid dealing with overflows. */
 const size_t MAX_NUM_ENTITY_LEN = 7;
+
+inline int is_valid_numeric_entity(uint32_t entity_val)
+{
+	/* Some XML parsers will choke on entities with certain
+	 * values (mostly control characters.)
+	 *
+	 * According to lxml these are all problematic:
+	 *
+	 *	[xrange(0, 8),
+	 *	 xrange(11, 12),
+	 *	 xrange(14, 31),
+	 *	 xrange(55296, 57343),
+	 *	 xrange(65534, 65535)]
+	 */
+	return (entity_val > 8
+			&& (entity_val != 11 && entity_val > 12)
+			&& (entity_val < 14 || entity_val > 31)
+			&& (entity_val < 55296 || entity_val > 57343)
+			&& (entity_val != 65534 && entity_val != 65535)
+			&& entity_val <= MAX_NUM_ENTITY_VAL);
+}
+
 %}
 %%
 &AElig;

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -720,7 +720,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 	int numeric = 0;
 	int hex = 0;
 	int entity_base;
-	u_int64_t entity_val;
+	uint32_t entity_val;
 
 	if (end < size && data[end] == '#') {
 		numeric = 1;
@@ -751,7 +751,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 	if (end > content_start && end < size && data[end] == ';')
 		end++; /* well-formed entity */
 	else
-		return 0; /* lone '&' */
+		return 0; /* not an entity */
 
 	/* way too long to be a valid numeric entity */
 	if (numeric && content_end - content_start > MAX_NUM_ENTITY_LEN)
@@ -766,8 +766,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 		// This is ok because  it'll stop once it hits the ';'
 		entity_val = strtol((char*)data + content_start, NULL, entity_base);
-		// Outside of UCS range, many parsers will choke on this.
-		if (entity_val > MAX_NUM_ENTITY_VAL)
+		if (!is_valid_numeric_entity(entity_val))
 			return 0;
 	} else {
 		if (!is_allowed_named_entity((const char *)data, end))

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -62,20 +62,20 @@ struct link_ref {
 /*   offset is the number of valid chars before data */
 struct sd_markdown;
 typedef size_t
-(*char_trigger)(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+(*char_trigger)(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
 
-static size_t char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
 
 enum markdown_char_t {
 	MD_CHAR_NONE = 0,
@@ -357,7 +357,7 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 static void
 parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
 {
-	size_t i = 0, end = 0;
+	size_t i = 0, end = 0, last_special = 0;
 	uint8_t action = 0;
 	struct buf work = { 0, 0, 0, 0 };
 
@@ -382,12 +382,12 @@ parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t siz
 		if (end >= size) break;
 		i = end;
 
-		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i, size - i);
+		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i - last_special, size - i);
 		if (!end) /* no action from the callback */
 			end = i + 1;
 		else {
 			i += end;
-			end = i;
+			last_special = end = i;
 		}
 	}
 }
@@ -595,7 +595,7 @@ parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 /* char_emphasis • single and double emphasis parsing */
 static size_t
-char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	uint8_t c = data[0];
 	size_t ret;
@@ -629,9 +629,9 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_linebreak • '\n' preceded by two spaces (assuming linebreak != 0) */
 static size_t
-char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
-	if (offset < 2 || data[-1] != ' ' || data[-2] != ' ')
+	if (max_rewind < 2 || data[-1] != ' ' || data[-2] != ' ')
 		return 0;
 
 	/* removing the last space from ob and rendering */
@@ -644,7 +644,7 @@ char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t o
 
 /* char_codespan • '`' parsing a code span (assuming codespan != 0) */
 static size_t
-char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t end, nb = 0, i, f_begin, f_end;
 
@@ -687,7 +687,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_escape • '\\' backslash escape */
 static size_t
-char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>/^~";
 	struct buf work = { 0, 0, 0, 0 };
@@ -711,7 +711,7 @@ char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 /* char_entity • '&' escaped when it doesn't belong to an entity */
 static size_t
-char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t end = 1;
 	size_t content_start;
@@ -785,7 +785,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 /* char_langle_tag • '<' when tags or autolinks are allowed */
 static size_t
-char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	enum mkd_autolink altype = MKDA_NOT_AUTOLINK;
 	size_t end = tag_length(data, size, &altype);
@@ -810,7 +810,7 @@ char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 }
 
 static size_t
-char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link, *link_url, *link_text;
 	size_t link_len, rewind;
@@ -820,7 +820,7 @@ char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__www(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__www(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		link_url = rndr_newbuf(rndr, BUFFER_SPAN);
 		BUFPUTSL(link_url, "http://");
 		bufput(link_url, link->data, link->size);
@@ -842,7 +842,7 @@ char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 }
 
 static size_t
-char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -851,10 +851,10 @@ char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, ui
 		return 0;
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
-	if ((link_len = sd_autolink__subreddit(&rewind, link, data, offset, size)) > 0) {
+	if ((link_len = sd_autolink__subreddit(&rewind, link, data, max_rewind, size)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
-	} else if ((link_len = sd_autolink__username(&rewind, link, data, offset, size)) > 0) {
+	} else if ((link_len = sd_autolink__username(&rewind, link, data, max_rewind, size)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
 	}
@@ -864,7 +864,7 @@ char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, ui
 }
 
 static size_t
-char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -874,7 +874,7 @@ char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, siz
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__email(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__email(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_EMAIL, rndr->opaque);
 	}
@@ -884,7 +884,7 @@ char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, siz
 }
 
 static size_t
-char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -894,7 +894,7 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__url(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__url(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
 	}
@@ -905,9 +905,9 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 /* char_link • '[': parsing a link or an image */
 static size_t
-char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
-	int is_img = (offset && data[-1] == '!'), level;
+	int is_img = (max_rewind && data[-1] == '!'), level;
 	size_t i = 1, txt_e, link_b = 0, link_e = 0, title_b = 0, title_e = 0;
 	struct buf *content = 0;
 	struct buf *link = 0;
@@ -1142,7 +1142,7 @@ cleanup:
 }
 
 static size_t
-char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t sup_start, sup_len;
 	struct buf *sup;

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -11,6 +11,9 @@ cases = {
     'http://www.reddit.com':
         '<p><a href="http://www.reddit.com">http://www.reddit.com</a></p>\n',
 
+    'http://www.reddit.com/a\x00b':
+        '<p><a href="http://www.reddit.com/ab">http://www.reddit.com/ab</a></p>\n',
+
     '[foo](http://en.wikipedia.org/wiki/Link_(film\))':
         '<p><a href="http://en.wikipedia.org/wiki/Link_(film)">foo</a></p>\n',
 

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -3,6 +3,7 @@
 
 import snudown
 import unittest
+import itertools
 import cStringIO as StringIO
 
 
@@ -219,6 +220,24 @@ cases = {
     '&#x;':
         '<p>&amp;#x;</p>\n',
 }
+
+# Test that every illegal numeric entity is encoded as
+# it should be.
+ILLEGAL_NUMERIC_ENT_RANGES = (
+    xrange(0, 9),
+    xrange(11, 13),
+    xrange(14, 32),
+    xrange(55296, 57344),
+    xrange(65534, 65536),
+)
+
+invalid_ent_test_key = ''
+invalid_ent_test_val = ''
+for i in itertools.chain(*ILLEGAL_NUMERIC_ENT_RANGES):
+    invalid_ent_test_key += '&#%d;' % i
+    invalid_ent_test_val += '&amp;#%d;' % i
+
+cases[invalid_ent_test_key] = '<p>%s</p>\n' % invalid_ent_test_val
 
 wiki_cases = {
     '<table scope="foo"bar>':

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -166,6 +166,33 @@ cases = {
     '/R/reddit.com':
         '<p>/R/reddit.com</p>\n',
 
+    '/r/irc://foo.bar/':
+        '<p><a href="/r/irc">/r/irc</a>://foo.bar/</p>\n',
+
+    '/r/t:irc//foo.bar/':
+        '<p><a href="/r/t:irc//foo">/r/t:irc//foo</a>.bar/</p>\n',
+
+    '/r/all-irc://foo.bar/':
+        '<p><a href="/r/all-irc">/r/all-irc</a>://foo.bar/</p>\n',
+
+    '/r/foo+irc://foo.bar/':
+        '<p><a href="/r/foo+irc">/r/foo+irc</a>://foo.bar/</p>\n',
+
+    '/r/www.example.com':
+        '<p><a href="/r/www">/r/www</a>.example.com</p>\n',
+
+    '.http://reddit.com':
+        '<p>.<a href="http://reddit.com">http://reddit.com</a></p>\n',
+
+    '[r://<http://reddit.com/>](/aa)':
+        '<p><a href="/aa">r://<a href="http://reddit.com/">http://reddit.com/</a></a></p>\n',
+
+    '/u/http://www.reddit.com/user/reddit':
+        '<p><a href="/u/http">/u/http</a>://<a href="http://www.reddit.com/user/reddit">www.reddit.com/user/reddit</a></p>\n',
+
+    'www.http://example.com/':
+        '<p><a href="http://www.http://example.com/">www.http://example.com/</a></p>\n',
+
     ('|' * 5) + '\n' + ('-|' * 5) + '\n|\n':
         '<table><thead>\n<tr>\n' + ('<th></th>\n' * 4) + '</tr>\n</thead><tbody>\n<tr>\n<td colspan="4" ></td>\n</tr>\n</tbody></table>\n',
 


### PR DESCRIPTION
:eyeglasses: @spladug 

This should clear up the last of the `HAX` warnings from the applogs, except for those related to certain raw multibyte control chars. We can't easily deal with those here, so that'd need changes to souptest.

https://github.com/JordanMilne/snudown/commit/273990cf1a89a700b945ec34e8cbe31718b554a7 addresses the control char dropping in `houdini_escape_href` not working.

https://github.com/JordanMilne/snudown/commit/61b4286af02d08db4eefaf64dd214916c669c10c adds range checks to numeric entities and encodes all those that would be invalid in XML

https://github.com/JordanMilne/snudown/commit/4433ea7c907fda8871f0216b5eeee8d8282714a2 handles rewind issues when people do something like /u/https://www.reddit.com/user/largenocream. This was actually fish'd a while ago, but I was hoping to get it accepted into one of the more active Sundown forks before I merged it here. Didn't happen, but I'm 99% sure it's correct since [vmg did the exact same thing in rinku](https://github.com/vmg/rinku/commit/dc685c15e30d9a02a0144170798538ea4754f0a6).