### PR TITLE
Add additional superscripting support.

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1145,7 +1145,7 @@ cleanup:
 static size_t
 char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
 {
-	size_t sup_start, sup_len;
+	size_t sup_start, sup_len, brk_offset, num_brks;
 	struct buf *sup;
 
 	if (!rndr->cb.superscript)
@@ -1154,14 +1154,32 @@ char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 	if (size < 2)
 		return 0;
 
-	if (data[1] == '(') {
-		sup_start = sup_len = 2;
-
-		while (sup_len < size && data[sup_len] != ')' && data[sup_len - 1] != '\\')
+	// find a bracket after a string of carets
+	brk_offset = 0;
+	while (brk_offset < size && data[brk_offset] == '^')
+		brk_offset++;
+	
+	if (brk_offset < size && data[brk_offset] == '(') {
+		if (brk_offset == 1)
+			sup_start = sup_len = 2; // original behaviour
+		else
+			sup_start = sup_len = 1; // to parse additional carets later
+		
+		num_brks = 0; // enable wrapped brackets inside ^()
+		while (sup_len < size) {
+			if (num_brks == 0 && data[sup_len] == ')' && data[sup_len - 1] != '\\') break;
+			if (sup_len > brk_offset) {
+				if (num_brks > 0 && data[sup_len] == ')' && data[sup_len - 1] != '\\') num_brks--;
+				else if (data[sup_len] == '(' && data[sup_len - 1] != '\\') num_brks++;
+			}
 			sup_len++;
+		}
 
 		if (sup_len == size)
 			return 0;
+		
+		if (brk_offset > 1)
+			sup_len++; // to parse additional carets later
 	} else {
 		sup_start = sup_len = 1;
 

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -62,6 +62,18 @@ cases = {
     r'Escape\^superscript':
         '<p>Escape^superscript</p>\n',
 
+    r'^(Multiple words superscript)':
+        '<p><sup>Multiple words superscript</sup></p>\n',
+
+    r'^^^^(Multiple words superscript)':
+        '<p><sup><sup><sup><sup>Multiple words superscript</sup></sup></sup></sup></p>\n',
+
+    r'^^^^(Multiple words ^^(and even higher) superscript)':
+        '<p><sup><sup><sup><sup>Multiple words <sup><sup>and even higher</sup></sup> superscript</sup></sup></sup></sup></p>\n',
+
+    r'^^^^(Multiple words (without escaping brackets) superscript)':
+        '<p><sup><sup><sup><sup>Multiple words (without escaping brackets) superscript</sup></sup></sup></sup></p>\n',
+
     r'~~normal strikethrough~~':
         '<p><del>normal strikethrough</del></p>\n',
 


### PR DESCRIPTION
This PR enables the use of `^^(superscripting like this)` (renders as `<sup><sup>superscripting like this</sup></sup>`).

It also enables the use of `^(superscripting ^(even higher) like this)` (renders as `<sup>superscripting <sup>even higher</sup> like this</sup>`), which as a side effect enables brackets to be used inside of `^()` without the need to escape them.

This should be an easier alternative to people `^^^superscripting ^^^multiple ^^^times ^^^with ^^^multiple ^^^words ^^^like ^^^this`, and it kinda bugged me that such superscripting wasn't supported.