### PR TITLE
Add tools for fuzzing snudown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 build/
+dist/
 snudown.egg-info/
 src/html_entities.h
 *.pyc
 *.so
+*.so.*
+*.o
+/fuzzing/bin
+/fuzzing/testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "gumbo_snudown"]
+	path = fuzzing/gumbo_snudown
+	url = git@github.com:JordanMilne/gumbo-parser.git
+	branch = markdown_validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+For safety reasons, whenever you add or change something in Snudown,
+you should add a few test-cases that demonstrate your change and do a
+fuzzing run in `/fuzzing` by running `make afl`.
+
+This uses [American Fuzzy Lop](http://lcamtuf.coredump.cx/afl/) and a
+modified [Google Gumbo](https://github.com/google/gumbo-parser/) to ensure
+there is no way to generate invalid HTML, and that there are no unsafe
+memory operations.
+
+See [American Fuzzy Lop](http://lcamtuf.coredump.cx/afl/)'s instructions
+for your platform to get started.

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 2.8)
+
+# I really don't get GNU Make, and I couldn't figure out how to get it
+# to not pullute the normal obj dir with our AFL and ASANified obj
+# files. Feel free to convert it to vanilla make.
+
+set(HEADERS
+  ../html/houdini.h
+  ../html/html.h
+  ../src/autolink.h
+  ../src/buffer.h
+  ../src/html_blocks.h
+  ../src/html_entities.h
+  ../src/markdown.h
+  ../src/stack.h
+  )
+set(LIBRARY_SOURCES
+  ../html/houdini_href_e.c
+  ../html/houdini_html_e.c
+  ../html/html.c
+  ../html/html_smartypants.c
+  ../src/autolink.c
+  ../src/buffer.c
+  ../src/markdown.c
+  ../src/stack.c
+  ${HEADERS}
+  )
+
+set(PROGRAM "snudown-validator")
+set(PROGRAM_SOURCES
+  ${LIBRARY_SOURCES}
+  snudown-validator.c
+  )
+
+include_directories(. ../src ../html ./build/gumbo_snudown/include ${CMAKE_CURRENT_BINARY_DIR})
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/build/gumbo_snudown/lib)
+
+add_executable(${PROGRAM} ${PROGRAM_SOURCES})
+target_link_libraries(${PROGRAM} gumbo)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wno-error=parentheses")

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-# I really don't get GNU Make, and I couldn't figure out how to get it
-# to not pullute the normal obj dir with our AFL and ASANified obj
-# files. Feel free to convert it to vanilla make.
-
 set(HEADERS
   ../html/houdini.h
   ../html/html.h

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -1,0 +1,62 @@
+# Copyright (c) 2015, reddit inc.
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+all:		gumbo_snudown snudown-validator
+
+.PHONY:		all clean gumbo_snudown snudown-validator build_dir
+
+build_dir:
+	mkdir -p build
+
+# Our modified gumbo for finding security-relevant syntax issues
+gumbo_snudown: build_dir
+	mkdir -p build/gumbo_snudown
+	git submodule update --recursive
+	@[ -f "${CURDIR}/gumbo_snudown/configure" ] || { \
+		cd gumbo_snudown; \
+		./autogen.sh; \
+		./configure --prefix=$(CURDIR)/build/gumbo_snudown; \
+	}
+	# Don't build this with AFL instrumentation, I'm assuming Google
+	# already ran their own fuzzer over their own parser...
+	$(MAKE) -C gumbo_snudown all install
+
+gperf_src:
+	cd ../src/ && gperf html_entities.gperf --output-file=html_entities.h
+
+# executable
+snudown-validator: $(SUNDOWN_VALIDATOR_SRC) build_dir gumbo_snudown gperf_src
+	cd build && cmake .. -DCMAKE_C_COMPILER=$(AFL_PATH)/afl-gcc
+	$(MAKE) -C build all
+
+# stuff for fuzzing
+gen_testcases:
+	mkdir -p testing/testcases
+	rm -f testing/testcases/test_default_*.md
+	python2.7 gen_testcases.py
+
+afl: gen_testcases snudown-validator
+	@[ -n "$(AFL_PATH)" ] || { echo '$$AFL_PATH not set'; false; }
+	@mkdir -p afl_results
+	$(AFL_PATH)/afl-fuzz \
+	    -i testing/testcases \
+	    -o testing/afl_results \
+	    -t 35 \
+	    -m none \
+	    ./build/snudown-validator
+
+# housekeeping
+clean:
+	rm -rf *.o
+	rm -rf build/

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -36,7 +36,7 @@ gperf_src:
 	cd ../src/ && gperf html_entities.gperf --output-file=html_entities.h
 
 # executable
-snudown-validator: $(SUNDOWN_VALIDATOR_SRC) build_dir gumbo_snudown gperf_src
+snudown-validator: build_dir gumbo_snudown gperf_src
 	cd build && cmake .. -DCMAKE_C_COMPILER=$(AFL_PATH)/afl-gcc
 	$(MAKE) -C build all
 
@@ -48,7 +48,7 @@ gen_testcases:
 
 afl: gen_testcases snudown-validator
 	@[ -n "$(AFL_PATH)" ] || { echo '$$AFL_PATH not set'; false; }
-	@mkdir -p afl_results
+	@mkdir -p testing/afl_results
 	$(AFL_PATH)/afl-fuzz \
 	    -i testing/testcases \
 	    -o testing/afl_results \

--- a/fuzzing/gen_testcases.py
+++ b/fuzzing/gen_testcases.py
@@ -1,0 +1,17 @@
+#!/bin/env python
+
+# dump all of our testcases into a directory as separate files, like AFL
+# wants.
+
+import os.path
+import sys
+import itertools
+
+sys.path.append("..")
+import test_snudown
+
+cases = itertools.chain(test_snudown.cases.keys(), test_snudown.wiki_cases.keys())
+for i, md in enumerate(cases):
+    test_path = os.path.join('testing', 'testcases', 'test_default_%d.md' % i)
+    with open(test_path, 'w') as f:
+        f.write(md)

--- a/fuzzing/snudown-validator.c
+++ b/fuzzing/snudown-validator.c
@@ -1,0 +1,223 @@
+#include "markdown.h"
+#include "html.h"
+#include "buffer.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include <gumbo.h>
+
+#define READ_UNIT 1024
+#define OUTPUT_UNIT 64
+
+#include "autolink.h"
+
+#define SNUDOWN_VERSION "1.3.2"
+
+enum snudown_renderer_mode {
+	RENDERER_USERTEXT = 0,
+	RENDERER_WIKI,
+	RENDERER_COUNT
+};
+
+struct snudown_renderopt {
+	struct html_renderopt html;
+	int nofollow;
+	const char *target;
+};
+
+struct snudown_renderer {
+	struct sd_markdown* main_renderer;
+	struct sd_markdown* toc_renderer;
+	struct module_state* state;
+	struct module_state* toc_state;
+};
+
+struct module_state {
+	struct sd_callbacks callbacks;
+	struct snudown_renderopt options;
+};
+
+static struct snudown_renderer sundown[RENDERER_COUNT];
+
+static char* html_element_whitelist[] = {"tr", "th", "td", "table", "tbody", "thead", "tfoot", "caption", NULL};
+static char* html_attr_whitelist[] = {"colspan", "rowspan", "cellspacing", "cellpadding", "scope", NULL};
+
+static struct module_state usertext_toc_state;
+static struct module_state wiki_toc_state;
+static struct module_state usertext_state;
+static struct module_state wiki_state;
+
+static const unsigned int snudown_default_md_flags =
+	MKDEXT_NO_INTRA_EMPHASIS |
+	MKDEXT_SUPERSCRIPT |
+	MKDEXT_AUTOLINK |
+	MKDEXT_STRIKETHROUGH |
+	MKDEXT_TABLES |
+	MKDEXT_NO_EMAIL_AUTOLINK;
+
+static const unsigned int snudown_default_render_flags =
+	HTML_SKIP_HTML |
+	HTML_SKIP_IMAGES |
+	HTML_SAFELINK |
+	HTML_ESCAPE |
+	HTML_USE_XHTML;
+
+static const unsigned int snudown_wiki_render_flags =
+	HTML_SKIP_HTML |
+	HTML_SAFELINK |
+	HTML_ALLOW_ELEMENT_WHITELIST |
+	HTML_ESCAPE |
+	HTML_USE_XHTML;
+
+static void
+snudown_link_attr(struct buf *ob, const struct buf *link, void *opaque)
+{
+	struct snudown_renderopt *options = opaque;
+
+	if (options->nofollow)
+		BUFPUTSL(ob, " rel=\"nofollow\"");
+
+	if (options->target != NULL) {
+		BUFPUTSL(ob, " target=\"");
+		bufputs(ob, options->target);
+		bufputc(ob, '\"');
+	}
+}
+
+static struct sd_markdown* make_custom_renderer(struct module_state* state,
+												const unsigned int renderflags,
+												const unsigned int markdownflags,
+												int toc_renderer) {
+	if(toc_renderer) {
+		sdhtml_toc_renderer(&state->callbacks,
+			(struct html_renderopt *)&state->options);
+	} else {
+		sdhtml_renderer(&state->callbacks,
+			(struct html_renderopt *)&state->options,
+			renderflags);
+	}
+
+	state->options.html.link_attributes = &snudown_link_attr;
+	state->options.html.html_element_whitelist = html_element_whitelist;
+	state->options.html.html_attr_whitelist = html_attr_whitelist;
+
+	return sd_markdown_new(
+		markdownflags,
+		16,
+		64,
+		&state->callbacks,
+		&state->options
+	);
+}
+
+void init_default_renderer() {
+	sundown[RENDERER_USERTEXT].main_renderer = make_custom_renderer(&usertext_state, snudown_default_render_flags, snudown_default_md_flags, 0);
+	sundown[RENDERER_USERTEXT].toc_renderer = make_custom_renderer(&usertext_toc_state, snudown_default_render_flags, snudown_default_md_flags, 1);
+	sundown[RENDERER_USERTEXT].state = &usertext_state;
+	sundown[RENDERER_USERTEXT].toc_state = &usertext_toc_state;
+}
+
+void init_wiki_renderer() {
+	sundown[RENDERER_WIKI].main_renderer = make_custom_renderer(&wiki_state, snudown_wiki_render_flags, snudown_default_md_flags, 0);
+	sundown[RENDERER_WIKI].toc_renderer = make_custom_renderer(&wiki_toc_state, snudown_wiki_render_flags, snudown_default_md_flags, 1);
+	sundown[RENDERER_WIKI].state = &wiki_state;
+	sundown[RENDERER_WIKI].toc_state = &wiki_toc_state;
+}
+
+void
+snudown_md(struct buf *ob, const uint8_t *document, size_t doc_size, int wiki_mode)
+{
+	int renderer = RENDERER_USERTEXT;
+	int enable_toc = 0;
+	struct snudown_renderer _snudown;
+	int nofollow = 0;
+	char* target = NULL;
+	char* toc_id_prefix = NULL;
+	unsigned int flags;
+
+	if (wiki_mode)
+		renderer = RENDERER_WIKI;
+
+	_snudown = sundown[renderer];
+
+	struct snudown_renderopt *options = &(_snudown.state->options);
+	options->nofollow = nofollow;
+	options->target = target;
+
+	flags = options->html.flags;
+
+	if (enable_toc) {
+		_snudown.toc_state->options.html.toc_id_prefix = toc_id_prefix;
+		sd_markdown_render(ob, document, doc_size, _snudown.toc_renderer);
+		_snudown.toc_state->options.html.toc_id_prefix = NULL;
+
+		options->html.flags |= HTML_TOC;
+	}
+
+	options->html.toc_id_prefix = toc_id_prefix;
+
+	/* do the magic */
+	sd_markdown_render(ob, document, doc_size, _snudown.main_renderer);
+
+	options->html.toc_id_prefix = NULL;
+	options->html.flags = flags;
+}
+int
+main(int argc, char **argv)
+{
+	init_default_renderer();
+	init_wiki_renderer();
+
+	struct buf *ib, *ob;
+	int size_read = 0, wiki_mode = 0, i = 0, have_errors = 0;
+
+	/* reading everything */
+	ib = bufnew(READ_UNIT);
+	bufgrow(ib, READ_UNIT);
+	while ((size_read = fread(ib->data + ib->size, 1, ib->asize - ib->size, stdin)) > 0) {
+		ib->size += size_read;
+		bufgrow(ib, ib->size + READ_UNIT);
+	}
+	/* Render to a buffer, then print that out */
+	ob = bufnew(OUTPUT_UNIT);
+	bufputs(ob, "<!DOCTYPE html><html><body>\n");
+	snudown_md(ob, ib->data, ib->size, wiki_mode);
+	bufputs(ob, "</body></html>\n");
+	GumboOutput* output = gumbo_parse_with_options(&kGumboDefaultOptions, bufcstr(ob), ob->size);
+
+	for (i=0; i < output->errors.length; ++i) {
+		// stupid "public" API I hacked in.
+		void* thing = output->errors.data[i];
+		GumboErrorType type = gumbo_get_error_type(thing);
+		switch(type) {
+			case GUMBO_ERR_UTF8_INVALID:
+			case GUMBO_ERR_UTF8_NULL:
+				// Making sure the user gave us valid
+				// utf-8 or transforming it to valid
+				// utf-8 is outside the scope of snudown
+				continue;
+			default:
+				have_errors = 1;
+				printf("%s\n", GUMBO_ERROR_NAMES[type]);
+				printf("%s\n",gumbo_get_error_text(thing));
+				printf("===============\n");
+				break;
+		}
+	}
+
+	if (have_errors) {
+		// gotta trigger a crash for AFL to catch it
+		assert(0);
+	}
+
+	gumbo_destroy_output(&kGumboDefaultOptions, output);
+	bufrelease(ob);
+	bufrelease(ib);
+	return 0;
+}

--- a/fuzzing/triageerrors.sh
+++ b/fuzzing/triageerrors.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find testing/afl_results/ -regextype posix-egrep -regex ".*/(crashes|hangs)/.*" | xargs -I '{}' ./validatemd.sh {}

--- a/fuzzing/validatemd.sh
+++ b/fuzzing/validatemd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "** ${1}"
+./build/snudown-validator < $1

--- a/html/houdini_href_e.c
+++ b/html/houdini_href_e.c
@@ -62,7 +62,9 @@ houdini_escape_href(struct buf *ob, const uint8_t *src, size_t size)
 
 	while (i < size) {
 		org = i;
-		while (i < size && HREF_SAFE[src[i]] != 0)
+		/* Skip by characters that don't need special
+		 * processing */
+		while (i < size && HREF_SAFE[src[i]] == 1)
 			i++;
 
 		if (i > org)

--- a/src/autolink.c
+++ b/src/autolink.c
@@ -51,7 +51,7 @@ sd_autolink_issafe(const uint8_t *link, size_t link_len)
 }
 
 static size_t
-autolink_delim(uint8_t *data, size_t link_end, size_t offset, size_t size)
+autolink_delim(uint8_t *data, size_t link_end, size_t max_rewind, size_t size)
 {
 	uint8_t cclose, copen = 0;
 	size_t i;
@@ -170,13 +170,13 @@ sd_autolink__www(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
 	size_t link_end;
 
-	if (offset > 0 && !ispunct(data[-1]) && !isspace(data[-1]))
+	if (max_rewind > 0 && !ispunct(data[-1]) && !isspace(data[-1]))
 		return 0;
 
 	if (size < 4 || memcmp(data, "www.", strlen("www.")) != 0)
@@ -190,7 +190,7 @@ sd_autolink__www(
 	while (link_end < size && !isspace(data[link_end]))
 		link_end++;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -206,14 +206,14 @@ sd_autolink__email(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
 	size_t link_end, rewind;
 	int nb = 0, np = 0;
 
-	for (rewind = 0; rewind < offset; ++rewind) {
+	for (rewind = 0; rewind < max_rewind; ++rewind) {
 		uint8_t c = data[-rewind - 1];
 
 		if (c == 0)
@@ -248,7 +248,7 @@ sd_autolink__email(
 	if (link_end < 2 || nb != 1 || np == 0)
 		return 0;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -264,7 +264,7 @@ sd_autolink__url(
 	size_t *rewind_p,
 	struct buf *link,
 	uint8_t *data,
-	size_t offset,
+	size_t max_rewind,
 	size_t size,
 	unsigned int flags)
 {
@@ -273,7 +273,7 @@ sd_autolink__url(
 	if (size < 4 || data[1] != '/' || data[2] != '/')
 		return 0;
 
-	while (rewind < offset && isalpha(data[-rewind - 1]))
+	while (rewind < max_rewind && isalpha(data[-rewind - 1]))
 		rewind++;
 
 	if (!sd_autolink_issafe(data - rewind, size + rewind))
@@ -293,7 +293,7 @@ sd_autolink__url(
 	while (link_end < size && !isspace(data[link_end]))
 		link_end++;
 
-	link_end = autolink_delim(data, link_end, offset, size);
+	link_end = autolink_delim(data, link_end, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;
@@ -305,7 +305,7 @@ sd_autolink__url(
 }
 
 size_t
-sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t offset, size_t size)
+sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t link_end;
 	int is_allminus = 0;
@@ -376,7 +376,7 @@ sd_autolink__subreddit(size_t *rewind_p, struct buf *link, uint8_t *data, size_t
 }
 
 size_t
-sd_autolink__username(size_t *rewind_p, struct buf *link, uint8_t *data, size_t offset, size_t size)
+sd_autolink__username(size_t *rewind_p, struct buf *link, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t link_end;
 

--- a/src/html_entities.gperf
+++ b/src/html_entities.gperf
@@ -8,11 +8,33 @@
 %{
 #include <stdlib.h>
 
-// Parsers tend to choke on entities with values greater than this
+/* Parsers tend to choke on entities with values greater than this */
 const u_int32_t MAX_NUM_ENTITY_VAL = 0x10ffff;
-// Any numeric entity longer than this is obviously above MAX_ENTITY_CHAR
-// used to avoid dealing with overflows.
+/* Any numeric entity longer than this is obviously above MAX_NUM_ENTITY_VAL
+ * used to avoid dealing with overflows. */
 const size_t MAX_NUM_ENTITY_LEN = 7;
+
+inline int is_valid_numeric_entity(uint32_t entity_val)
+{
+	/* Some XML parsers will choke on entities with certain
+	 * values (mostly control characters.)
+	 *
+	 * According to lxml these are all problematic:
+	 *
+	 *	[xrange(0, 8),
+	 *	 xrange(11, 12),
+	 *	 xrange(14, 31),
+	 *	 xrange(55296, 57343),
+	 *	 xrange(65534, 65535)]
+	 */
+	return (entity_val > 8
+			&& (entity_val != 11 && entity_val > 12)
+			&& (entity_val < 14 || entity_val > 31)
+			&& (entity_val < 55296 || entity_val > 57343)
+			&& (entity_val != 65534 && entity_val != 65535)
+			&& entity_val <= MAX_NUM_ENTITY_VAL);
+}
+
 %}
 %%
 &AElig;

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -720,7 +720,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 	int numeric = 0;
 	int hex = 0;
 	int entity_base;
-	u_int64_t entity_val;
+	uint32_t entity_val;
 
 	if (end < size && data[end] == '#') {
 		numeric = 1;
@@ -751,7 +751,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 	if (end > content_start && end < size && data[end] == ';')
 		end++; /* well-formed entity */
 	else
-		return 0; /* lone '&' */
+		return 0; /* not an entity */
 
 	/* way too long to be a valid numeric entity */
 	if (numeric && content_end - content_start > MAX_NUM_ENTITY_LEN)
@@ -766,8 +766,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 		// This is ok because  it'll stop once it hits the ';'
 		entity_val = strtol((char*)data + content_start, NULL, entity_base);
-		// Outside of UCS range, many parsers will choke on this.
-		if (entity_val > MAX_NUM_ENTITY_VAL)
+		if (!is_valid_numeric_entity(entity_val))
 			return 0;
 	} else {
 		if (!is_allowed_named_entity((const char *)data, end))

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -62,20 +62,20 @@ struct link_ref {
 /*   offset is the number of valid chars before data */
 struct sd_markdown;
 typedef size_t
-(*char_trigger)(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+(*char_trigger)(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
 
-static size_t char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
+static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size);
 
 enum markdown_char_t {
 	MD_CHAR_NONE = 0,
@@ -357,7 +357,7 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 static void
 parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
 {
-	size_t i = 0, end = 0;
+	size_t i = 0, end = 0, last_special = 0;
 	uint8_t action = 0;
 	struct buf work = { 0, 0, 0, 0 };
 
@@ -382,12 +382,12 @@ parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t siz
 		if (end >= size) break;
 		i = end;
 
-		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i, size - i);
+		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i - last_special, size - i);
 		if (!end) /* no action from the callback */
 			end = i + 1;
 		else {
 			i += end;
-			end = i;
+			last_special = end = i;
 		}
 	}
 }
@@ -595,7 +595,7 @@ parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 /* char_emphasis • single and double emphasis parsing */
 static size_t
-char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	uint8_t c = data[0];
 	size_t ret;
@@ -629,9 +629,9 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_linebreak • '\n' preceded by two spaces (assuming linebreak != 0) */
 static size_t
-char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
-	if (offset < 2 || data[-1] != ' ' || data[-2] != ' ')
+	if (max_rewind < 2 || data[-1] != ' ' || data[-2] != ' ')
 		return 0;
 
 	/* removing the last space from ob and rendering */
@@ -644,7 +644,7 @@ char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t o
 
 /* char_codespan • '`' parsing a code span (assuming codespan != 0) */
 static size_t
-char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t end, nb = 0, i, f_begin, f_end;
 
@@ -687,7 +687,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_escape • '\\' backslash escape */
 static size_t
-char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>/^~";
 	struct buf work = { 0, 0, 0, 0 };
@@ -711,7 +711,7 @@ char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 /* char_entity • '&' escaped when it doesn't belong to an entity */
 static size_t
-char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t end = 1;
 	size_t content_start;
@@ -785,7 +785,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 /* char_langle_tag • '<' when tags or autolinks are allowed */
 static size_t
-char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	enum mkd_autolink altype = MKDA_NOT_AUTOLINK;
 	size_t end = tag_length(data, size, &altype);
@@ -810,7 +810,7 @@ char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 }
 
 static size_t
-char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link, *link_url, *link_text;
 	size_t link_len, rewind;
@@ -820,7 +820,7 @@ char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__www(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__www(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		link_url = rndr_newbuf(rndr, BUFFER_SPAN);
 		BUFPUTSL(link_url, "http://");
 		bufput(link_url, link->data, link->size);
@@ -842,7 +842,7 @@ char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 }
 
 static size_t
-char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -851,10 +851,10 @@ char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, ui
 		return 0;
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
-	if ((link_len = sd_autolink__subreddit(&rewind, link, data, offset, size)) > 0) {
+	if ((link_len = sd_autolink__subreddit(&rewind, link, data, max_rewind, size)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
-	} else if ((link_len = sd_autolink__username(&rewind, link, data, offset, size)) > 0) {
+	} else if ((link_len = sd_autolink__username(&rewind, link, data, max_rewind, size)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
 	}
@@ -864,7 +864,7 @@ char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, ui
 }
 
 static size_t
-char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -874,7 +874,7 @@ char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, siz
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__email(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__email(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_EMAIL, rndr->opaque);
 	}
@@ -884,7 +884,7 @@ char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, siz
 }
 
 static size_t
-char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -894,7 +894,7 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__url(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__url(&rewind, link, data, max_rewind, size, 0)) > 0) {
 		buftruncate(ob, ob->size - rewind);
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
 	}
@@ -905,9 +905,9 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 /* char_link • '[': parsing a link or an image */
 static size_t
-char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
-	int is_img = (offset && data[-1] == '!'), level;
+	int is_img = (max_rewind && data[-1] == '!'), level;
 	size_t i = 1, txt_e, link_b = 0, link_e = 0, title_b = 0, title_e = 0;
 	struct buf *content = 0;
 	struct buf *link = 0;
@@ -1142,7 +1142,7 @@ cleanup:
 }
 
 static size_t
-char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t size)
 {
 	size_t sup_start, sup_len;
 	struct buf *sup;

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -11,6 +11,9 @@ cases = {
     'http://www.reddit.com':
         '<p><a href="http://www.reddit.com">http://www.reddit.com</a></p>\n',
 
+    'http://www.reddit.com/a\x00b':
+        '<p><a href="http://www.reddit.com/ab">http://www.reddit.com/ab</a></p>\n',
+
     '[foo](http://en.wikipedia.org/wiki/Link_(film\))':
         '<p><a href="http://en.wikipedia.org/wiki/Link_(film)">foo</a></p>\n',
 

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -3,6 +3,7 @@
 
 import snudown
 import unittest
+import itertools
 import cStringIO as StringIO
 
 
@@ -219,6 +220,24 @@ cases = {
     '&#x;':
         '<p>&amp;#x;</p>\n',
 }
+
+# Test that every illegal numeric entity is encoded as
+# it should be.
+ILLEGAL_NUMERIC_ENT_RANGES = (
+    xrange(0, 9),
+    xrange(11, 13),
+    xrange(14, 32),
+    xrange(55296, 57344),
+    xrange(65534, 65536),
+)
+
+invalid_ent_test_key = ''
+invalid_ent_test_val = ''
+for i in itertools.chain(*ILLEGAL_NUMERIC_ENT_RANGES):
+    invalid_ent_test_key += '&#%d;' % i
+    invalid_ent_test_val += '&amp;#%d;' % i
+
+cases[invalid_ent_test_key] = '<p>%s</p>\n' % invalid_ent_test_val
 
 wiki_cases = {
     '<table scope="foo"bar>':

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -166,6 +166,33 @@ cases = {
     '/R/reddit.com':
         '<p>/R/reddit.com</p>\n',
 
+    '/r/irc://foo.bar/':
+        '<p><a href="/r/irc">/r/irc</a>://foo.bar/</p>\n',
+
+    '/r/t:irc//foo.bar/':
+        '<p><a href="/r/t:irc//foo">/r/t:irc//foo</a>.bar/</p>\n',
+
+    '/r/all-irc://foo.bar/':
+        '<p><a href="/r/all-irc">/r/all-irc</a>://foo.bar/</p>\n',
+
+    '/r/foo+irc://foo.bar/':
+        '<p><a href="/r/foo+irc">/r/foo+irc</a>://foo.bar/</p>\n',
+
+    '/r/www.example.com':
+        '<p><a href="/r/www">/r/www</a>.example.com</p>\n',
+
+    '.http://reddit.com':
+        '<p>.<a href="http://reddit.com">http://reddit.com</a></p>\n',
+
+    '[r://<http://reddit.com/>](/aa)':
+        '<p><a href="/aa">r://<a href="http://reddit.com/">http://reddit.com/</a></a></p>\n',
+
+    '/u/http://www.reddit.com/user/reddit':
+        '<p><a href="/u/http">/u/http</a>://<a href="http://www.reddit.com/user/reddit">www.reddit.com/user/reddit</a></p>\n',
+
+    'www.http://example.com/':
+        '<p><a href="http://www.http://example.com/">www.http://example.com/</a></p>\n',
+
     ('|' * 5) + '\n' + ('-|' * 5) + '\n|\n':
         '<table><thead>\n<tr>\n' + ('<th></th>\n' * 4) + '</tr>\n</thead><tbody>\n<tr>\n<td colspan="4" ></td>\n</tr>\n</tbody></table>\n',
 


### PR DESCRIPTION
:eyeglasses: @spladug 

Only the last commit matters, the rest are from https://github.com/reddit/snudown/pull/69.

Automagically takes our testcases, plugs them into American Fuzzy
Lop, then makes sure that they output valid HTML.

I had a few issues getting the `Makefile` to work the way I wanted (I didn't want to pollute `src/` and `html/` with AFL-instrumented object files) so I ended up using CMake for the fuzzer. I'm not that concerned about it since it's a dev-only dependency, but def not ideal.

The other thing is my fork of `gumbo-parser` that gets included as a submodule. I had to hack out a few overly-general `ParserErrors` and add in an interface for the private, unstable error API so we could tell if we care about the error. Where should that live? 