### PR TITLE
Add blockspoiler support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,15 @@ Install
 Run `setup.py install` to install the module.
 
 
+Setup for development on Mac OS X
+---------------------------------
+
+For Mac OS X:
+1. Install `afl-fuzz` via homebrew: `brew install afl-fuzz`
+3. You can now install the module via `python setup.py install`
+4. You may also compile snudown using the Makefile directly if you so wish
+
+
 Thanks
 ------
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+snudown (1.5.0) unstable; urgency=medium
+  * add blockspoiler support
+  * add inline spoiler support
+
+ -- Jesjit Birak <jesjit.birak@reddit.com> Wed, 07 Mar 2018 13:21:45 -0800
+
 snudown (1.4.0) unstable; urgency=medium
 
   * autolink r/subreddit and u/user

--- a/fuzzing/Makefile
+++ b/fuzzing/Makefile
@@ -12,6 +12,18 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+OS := $(shell uname)
+
+ifeq ($(OS), Darwin)
+    AFL_COMPILER := "afl-clang"
+else
+    AFL_COMPILIER := "afl-gcc"
+endif
+
+ifneq ($(AFL_PATH),)
+    AFL_COMPILER := $(AFL_PATH)/$(AFL_COMPILER)
+endif
+
 all:		gumbo_snudown snudown-validator
 
 .PHONY:		all clean gumbo_snudown snudown-validator build_dir
@@ -37,7 +49,7 @@ gperf_src:
 
 # executable
 snudown-validator: build_dir gumbo_snudown gperf_src
-	cd build && cmake .. -DCMAKE_C_COMPILER=$(AFL_PATH)/afl-gcc
+	cd build && cmake .. -DCMAKE_C_COMPILER=$(AFL_COMPILER)
 	$(MAKE) -C build all
 
 # stuff for fuzzing

--- a/html/html.c
+++ b/html/html.c
@@ -162,6 +162,15 @@ rndr_blockquote(struct buf *ob, const struct buf *text, void *opaque)
 	BUFPUTSL(ob, "</blockquote>\n");
 }
 
+static void
+rndr_blockspoiler(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (ob->size) bufputc(ob, '\n');
+	BUFPUTSL(ob, "<blockquote class=\"md-spoiler-text\">\n");
+	if (text) bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "</blockquote>\n");
+}
+
 static int
 rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 {
@@ -741,6 +750,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 	static const struct sd_callbacks cb_default = {
 		rndr_blockcode,
 		rndr_blockquote,
+		rndr_blockspoiler,
 		rndr_raw_block,
 		rndr_header,
 		rndr_hrule,

--- a/html/html.c
+++ b/html/html.c
@@ -181,6 +181,19 @@ rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static int
+rndr_spoilerspan(struct buf *ob, const struct buf *text, void *opaque)
+{
+    if (!text || !text->size)
+        return 0;
+
+    BUFPUTSL(ob, "<span class=\"md-spoiler-text\">");
+    bufput(ob, text->data, text->size);
+    BUFPUTSL(ob, "</span>");
+
+    return 1;
+}
+
+static int
 rndr_strikethrough(struct buf *ob, const struct buf *text, void *opaque)
 {
 	if (!text || !text->size)
@@ -721,6 +734,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 
 		NULL,
 		rndr_codespan,
+		rndr_spoilerspan,
 		rndr_double_emphasis,
 		rndr_emphasis,
 		NULL,
@@ -763,6 +777,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 
 		rndr_autolink,
 		rndr_codespan,
+		rndr_spoilerspan,
 		rndr_double_emphasis,
 		rndr_emphasis,
 		rndr_image,

--- a/html_block_names.txt
+++ b/html_block_names.txt
@@ -23,3 +23,4 @@ style
 fieldset
 noscript
 blockquote
+span

--- a/snudown.c
+++ b/snudown.c
@@ -5,7 +5,7 @@
 #include "html.h"
 #include "autolink.h"
 
-#define SNUDOWN_VERSION "1.4.0"
+#define SNUDOWN_VERSION "1.5.0"
 
 enum snudown_renderer_mode {
 	RENDERER_USERTEXT = 0,

--- a/src/html_blocks.h
+++ b/src/html_blocks.h
@@ -187,7 +187,8 @@ find_block_tag (str, len)
       "", "", "",
       "h3",
       "", "", "", "",
-      "h2"
+      "h2",
+      "span"
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -405,6 +405,9 @@ find_emph_char(uint8_t *data, size_t size, uint8_t c)
 		if (i == size)
 			return 0;
 
+		if (i < size && c == '<' && data[i] == c && data[i-1] == '!')
+			return i;
+
 		if (data[i] == c)
 			return i;
 
@@ -593,6 +596,39 @@ parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 	return 0;
 }
 
+static size_t
+parse_spoilerspan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+{
+	int (*render_method)(struct buf *ob, const struct buf *text, void *opaque);
+	size_t len;
+	size_t i = 0;
+	struct buf *work = 0;
+	int r;
+
+	render_method = rndr->cb.spoilerspan;
+
+	if (!render_method) return 0;
+
+	while (i < size) {
+		len = find_emph_char(data + i, size - i, '<');
+		if (!len) return 0;
+		i += len;
+
+		if (i < size && data[i] == '<' && data[i - 1] == '!') {
+			work = rndr_newbuf(rndr, BUFFER_SPAN);
+			parse_inline(work, rndr, data, i - 1);
+			r = render_method(ob, work, rndr->opaque);
+			rndr_popbuf(rndr, BUFFER_SPAN);
+
+			if (!r) return 0;
+
+			return i + 1;
+		}
+		i++;
+	}
+	return 0;
+}
+
 /* char_emphasis • single and double emphasis parsing */
 static size_t
 char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size)
@@ -600,14 +636,23 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t ma
 	uint8_t c = data[0];
 	size_t ret;
 
+	if (size > 3 && c == '>' && data[1] == '!') {
+		if(_isspace(data[2]) || (ret = parse_spoilerspan(ob, rndr, data + 2, size - 2)) == 0)
+			return 0;
+
+		return ret + 2;
+	}
+
+
 	if (size > 2 && data[1] != c) {
 		/* whitespace cannot follow an opening emphasis;
 		 * strikethrough only takes two characters '~~' */
-		if (c == '~' || _isspace(data[1]) || (ret = parse_emph1(ob, rndr, data + 1, size - 1, c)) == 0)
+		if (c == '~' || c == '>' || _isspace(data[1]) || (ret = parse_emph1(ob, rndr, data + 1, size - 1, c)) == 0)
 			return 0;
 
 		return ret + 1;
 	}
+
 
 	if (size > 3 && data[1] == c && data[2] != c) {
 		if (_isspace(data[2]) || (ret = parse_emph2(ob, rndr, data + 2, size - 2, c)) == 0)
@@ -617,7 +662,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t ma
 	}
 
 	if (size > 4 && data[1] == c && data[2] == c && data[3] != c) {
-		if (c == '~' || _isspace(data[3]) || (ret = parse_emph3(ob, rndr, data + 3, size - 3, c)) == 0)
+		if (c == '~' || c == '>' || _isspace(data[3]) || (ret = parse_emph3(ob, rndr, data + 3, size - 3, c)) == 0)
 			return 0;
 
 		return ret + 3;
@@ -1403,7 +1448,7 @@ prefix_quote(uint8_t *data, size_t size)
 	if (i < size && data[i] == ' ') i++;
 	if (i < size && data[i] == ' ') i++;
 
-	if ((i < size && data[i] == '>') && (i + 1 <= size && data[i+1] != '!')) {
+	if ((i < size && data[i] == '>') && (i + 1 < size && data[i+1] != '!')) {
 		if (i + 1 < size && data[i + 1] == ' ')
 			return i + 2;
 
@@ -1422,10 +1467,14 @@ prefix_blockspoiler(uint8_t *data, size_t size)
     if (i < size && data[i] == ' ') i++;
 
     if (i + 1 < size && data[i] == '>' && data[i + 1] == '!') {
-            if (i + 2 < size && data[i + 2] == ' ')
-                    return i + 3;
+		size_t spoilerspan = find_emph_char(data + i + 1, size - i - 1, '<');
+		if (i + spoilerspan < size && spoilerspan > 0 && data[i + spoilerspan] == '!')
+			return 0;
 
-            return i + 2;
+		if (i + 2 < size && data[i + 2] == ' ')
+			return i + 3;
+
+		return i + 2;
     }
 
     return 0;
@@ -2583,6 +2632,7 @@ sd_markdown_new(
 	if (md->cb.emphasis || md->cb.double_emphasis || md->cb.triple_emphasis) {
 		md->active_char['*'] = MD_CHAR_EMPHASIS;
 		md->active_char['_'] = MD_CHAR_EMPHASIS;
+		md->active_char['>'] = MD_CHAR_EMPHASIS;
 		if (extensions & MKDEXT_STRIKETHROUGH)
 			md->active_char['~'] = MD_CHAR_EMPHASIS;
 	}

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -82,6 +82,7 @@ struct sd_callbacks {
 	/* span level callbacks - NULL or return 0 prints the span verbatim */
 	int (*autolink)(struct buf *ob, const struct buf *link, enum mkd_autolink type, void *opaque);
 	int (*codespan)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*spoilerspan)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*double_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*image)(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *alt, void *opaque);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -67,6 +67,7 @@ struct sd_callbacks {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(struct buf *ob, const struct buf *text, const struct buf *lang, void *opaque);
 	void (*blockquote)(struct buf *ob, const struct buf *text, void *opaque);
+	void (*blockspoiler)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*blockhtml)(struct buf *ob,const  struct buf *text, void *opaque);
 	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);
 	void (*hrule)(struct buf *ob, void *opaque);

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -333,7 +333,73 @@ cases = {
 
     '&#x;':
         '<p>&amp;#x;</p>\n',
+    '> quotey mcquoteface':
+        '<blockquote>\n<p>quotey mcquoteface</p>\n</blockquote>\n',
+
+    '> quotey mcquoteface\nnew line of text what happens?':
+        '<blockquote>\n<p>quotey mcquoteface\nnew line of text what happens?</p>\n</blockquote>\n',
+
+    '> quotey mcquoteface\n\ntwo new lines then text what happens?':
+        '<blockquote>\n<p>quotey mcquoteface</p>\n</blockquote>\n\n<p>two new lines then text what happens?</p>\n',
+
+    '> quotey mcquoteface\n> more quotey':
+        '<blockquote>\n<p>quotey mcquoteface\nmore quotey</p>\n</blockquote>\n',
+
+    '> quotey macquoteface\n\n> another quotey':
+        '<blockquote>\n<p>quotey macquoteface</p>\n\n<p>another quotey</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface\nmore spoilage goes here':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface\nmore spoilage goes here</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface > incorrect quote syntax':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface &gt; incorrect quote syntax</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface\n\n':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface\n\nnormal text here':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface</p>\n</blockquote>\n\n<p>normal text here</p>\n',
+
+    '>! spoily mcspoilerface\n>! blockspoiler continuation':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface\nblockspoiler continuation</p>\n</blockquote>\n',
+
+    '>! spoily mcspoilerface\n> quotey mcquoteface':
+        '<blockquote class="md-spoiler-text">\n<p>spoily mcspoilerface</p>\n\n<blockquote>\n<p>quotey mcquoteface</p>\n</blockquote>\n</blockquote>\n',
+
+    '>! spoiler p1\n>!\n>! spoiler p2\n>! spoiler p3':
+        '<blockquote class="md-spoiler-text">\n<p>spoiler p1</p>\n\n<p>spoiler p2\nspoiler p3</p>\n</blockquote>\n',
+
+    '>>! spoiler p1\n>!\n>! spoiler p2\n>! spoiler p3':
+        '<blockquote>\n<blockquote class="md-spoiler-text">\n<p>spoiler p1</p>\n\n<p>spoiler p2\nspoiler p3</p>\n</blockquote>\n</blockquote>\n',
+
+    '>>! spoiler p1\n>!\n>! spoiler p2\n\nnew text':
+        '<blockquote>\n<blockquote class="md-spoiler-text">\n<p>spoiler p1</p>\n\n<p>spoiler p2</p>\n</blockquote>\n</blockquote>\n\n<p>new text</p>\n',
+
+    '>>! spoiler p1\n>!\n>! spoiler p2\n\n>! new blockspoiler':
+        '<blockquote>\n<blockquote class="md-spoiler-text">\n<p>spoiler p1</p>\n\n<p>spoiler p2</p>\n</blockquote>\n</blockquote>\n\n<blockquote class="md-spoiler-text">\n<p>new blockspoiler</p>\n</blockquote>\n',
+
+    '! this is not a spoiler':
+        '<p>! this is not a spoiler</p>\n',
+
+    '>!\nTesting':
+        '<blockquote class="md-spoiler-text">\n<p>Testing</p>\n</blockquote>\n',
+
+    '>!\n\nTesting':
+        '<blockquote class="md-spoiler-text">\n</blockquote>\n\n<p>Testing</p>\n',
+
+    '>!':
+        '<blockquote class="md-spoiler-text">\n</blockquote>\n',
+    '>!\n>!':
+        '<blockquote class="md-spoiler-text">\n</blockquote>\n',
+    '>':
+        '<blockquote>\n</blockquote>\n',
+    '> some quote goes here\n>':
+        '<blockquote>\n<p>some quote goes here</p>\n</blockquote>\n',
 }
+
 
 # Test that every numeric entity is encoded as
 # it should be.
@@ -459,3 +525,7 @@ def test_snudown():
         suite.addTest(case)
 
     return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(test_snudown())

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -398,6 +398,16 @@ cases = {
         '<blockquote>\n</blockquote>\n',
     '> some quote goes here\n>':
         '<blockquote>\n<p>some quote goes here</p>\n</blockquote>\n',
+    'This is an >!inline spoiler!< sentence.':
+        '<p>This is an <span class="md-spoiler-text">inline spoiler</span> sentence.</p>\n',
+    '>!Inline spoiler!< starting the sentence':
+        '<p><span class="md-spoiler-text">Inline spoiler</span> starting the sentence</p>\n',
+    'Inline >!spoiler with *emphasis*!< test':
+        '<p>Inline <span class="md-spoiler-text">spoiler with <em>emphasis</em></span> test</p>\n',
+    '>! This is an illegal blockspoiler >!with an inline spoiler!<':
+        '<p>&gt;! This is an illegal blockspoiler <span class="md-spoiler-text">with an inline spoiler</span></p>\n',
+    'This is an >!inline spoiler with some >!additional!< text!<':
+        '<p>This is an <span class="md-spoiler-text">inline spoiler with some &gt;!additional</span> text!&lt;</p>\n'
 }
 
 


### PR DESCRIPTION
Added blockspoilers to snudown. Took inspiration from Stack Overflow and decided to use `>!` as the syntax to declare a blockspoiler. Some examples a blockspoiler would look like the following:

```
>! This is a blockspoiler
```

```
>! This is a blockspoiler
this is still part of the blockspoiler

This is no longer part of the blockspoiler
```

```
>>! Blockspoiler in blockquote
```

More examples and cases can be found in `test_snudown.py`. I also added some additional cases for blockquoting as it seemed like we were missing test cases for blockquotes as well. 

I also added some instructions on how to get started developing on Mac OS X in the README. 

:eyeglasses: @spladug @pwildani 