### PR TITLE
Add an enter_* callbacks for widget toolkit consumers

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1510,6 +1510,8 @@ parse_blockquote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 		beg = end;
 	}
 
+	if (rndr->cb.enter_blockquote)
+		rndr->cb.enter_blockquote(ob, rndr->opaque);
 	parse_block(out, rndr, work_data, work_size);
 	if (rndr->cb.blockquote)
 		rndr->cb.blockquote(ob, out, rndr->opaque);
@@ -1745,6 +1747,9 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 	while (end < size && data[end - 1] != '\n')
 		end++;
 
+	if (rndr->cb.enter_listitem)
+		rndr->cb.enter_listitem(ob, rndr->opaque);
+
 	/* getting working buffers */
 	work = rndr_newbuf(rndr, BUFFER_SPAN);
 	inter = rndr_newbuf(rndr, BUFFER_SPAN);
@@ -1864,6 +1869,9 @@ parse_list(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size,
 {
 	struct buf *work = 0;
 	size_t i = 0, j;
+
+	if (rndr->cb.enter_list)
+		rndr->cb.enter_list(ob, rndr->opaque);
 
 	work = rndr_newbuf(rndr, BUFFER_BLOCK);
 
@@ -2092,6 +2100,9 @@ parse_table_row(
 	if (!rndr->cb.table_cell || !rndr->cb.table_row)
 		return;
 
+        if (rndr->cb.enter_table_row)
+                rndr->cb.enter_table_row(ob, header_flag, rndr->opaque);
+
 	row_work = rndr_newbuf(rndr, BUFFER_SPAN);
 
 	if (i < size && data[i] == '|')
@@ -2100,6 +2111,9 @@ parse_table_row(
 	for (col = 0; col < columns && i < size; ++col) {
 		size_t cell_start, cell_end;
 		struct buf *cell_work;
+
+                if (rndr->cb.enter_table_cell)
+                        rndr->cb.enter_table_cell(ob, header_flag, rndr->opaque);
 
 		cell_work = rndr_newbuf(rndr, BUFFER_SPAN);
 
@@ -2125,6 +2139,8 @@ parse_table_row(
 
 	cols_left = columns - col;
 	if (cols_left > 0) {
+                if (rndr->cb.enter_table_cell)
+                        rndr->cb.enter_table_cell(ob, header_flag, rndr->opaque);
 		struct buf empty_cell = { 0, 0, 0, 0 };
 		rndr->cb.table_cell(row_work, &empty_cell, col_data[col] | header_flag, rndr->opaque, cols_left);
 	}
@@ -2215,6 +2231,9 @@ parse_table_header(
 	if (col < *columns)
 		return 0;
 
+        if (rndr->cb.enter_table)
+                rndr->cb.enter_table(ob, rndr->opaque);
+
 	parse_table_row(
 		ob, rndr, data,
 		header_end,
@@ -2246,7 +2265,6 @@ parse_table(
 
 	i = parse_table_header(header_work, rndr, data, size, &columns, &col_data);
 	if (i > 0) {
-
 		while (i < size) {
 			size_t row_start;
 			int pipes = 0;

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -98,6 +98,14 @@ struct sd_callbacks {
 	/* header and footer */
 	void (*doc_header)(struct buf *ob, void *opaque);
 	void (*doc_footer)(struct buf *ob, void *opaque);
+
+	/* enter_X callbacks for use in widget toolkits */
+	void (*enter_blockquote)(struct buf *ob, void *opaque);
+	void (*enter_list)(struct buf *ob, void *opaque);
+	void (*enter_listitem)(struct buf *ob, void *opaque);
+	void (*enter_table)(struct buf *ob, void *opaque);
+	void (*enter_table_row)(struct buf *ob, int header_flags, void *opaque);
+	void (*enter_table_cell)(struct buf *ob, int header_flags, void *opaque);
 };
 
 struct sd_markdown;


### PR DESCRIPTION
These callback is useful for widget toolkit users of the render, which
need to insert a widget at when entering (as well as exiting) some of
the block or table types.  This is what we are using in
something-for-reddit which uses the Gtk+ widget toolkit.  For example,
we add a table in the "enter_table" callback, and mark the table as
completed during the "table" callback.