### PR TITLE
Identify and skip unrenderable snoomark syntaxes

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -184,6 +184,16 @@ rndr_strikethrough(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static int
+rndr_underline(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size)
+		return 0;
+
+	bufput(ob, text->data, text->size);
+	return 1;
+}
+
+static int
 rndr_double_emphasis(struct buf *ob, const struct buf *text, void *opaque)
 {
 	if (!text || !text->size)
@@ -728,6 +738,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		NULL,
 		rndr_triple_emphasis,
 		rndr_strikethrough,
+		rndr_underline,
 		rndr_superscript,
 		rndr_subscript,
 
@@ -770,6 +781,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		rndr_raw_html,
 		rndr_triple_emphasis,
 		rndr_strikethrough,
+		rndr_underline,
 		rndr_superscript,
 		rndr_subscript,
 

--- a/html/html.c
+++ b/html/html.c
@@ -614,6 +614,14 @@ rndr_superscript(struct buf *ob, const struct buf *text, void *opaque)
 	return 1;
 }
 
+static int
+rndr_subscript(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size) return 0;
+	bufput(ob, text->data, text->size);
+	return 1;
+}
+
 static void
 rndr_normal_text(struct buf *ob, const struct buf *text, void *opaque)
 {
@@ -721,6 +729,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		rndr_subscript,
 
 		NULL,
 		NULL,
@@ -762,6 +771,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		rndr_subscript,
 
 		NULL,
 		rndr_normal_text,

--- a/snudown.c
+++ b/snudown.c
@@ -48,6 +48,7 @@ PyDoc_STRVAR(snudown_md__doc__, "Render a Markdown document");
 static const unsigned int snudown_default_md_flags =
 	MKDEXT_NO_INTRA_EMPHASIS |
 	MKDEXT_SUPERSCRIPT |
+	MKDEXT_SUBSCRIPT |
 	MKDEXT_AUTOLINK |
 	MKDEXT_STRIKETHROUGH |
 	MKDEXT_TABLES;

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -76,6 +76,7 @@ static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_
 static size_t char_autolink_subreddit_or_username(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size);
 static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size);
 static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size);
+static size_t char_subscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size);
 
 enum markdown_char_t {
 	MD_CHAR_NONE = 0,
@@ -91,6 +92,7 @@ enum markdown_char_t {
 	MD_CHAR_AUTOLINK_WWW,
 	MD_CHAR_AUTOLINK_SUBREDDIT_OR_USERNAME,
 	MD_CHAR_SUPERSCRIPT,
+	MD_CHAR_SUBSCRIPT,
 };
 
 static char_trigger markdown_char_ptrs[] = {
@@ -107,6 +109,7 @@ static char_trigger markdown_char_ptrs[] = {
 	&char_autolink_www,
 	&char_autolink_subreddit_or_username,
 	&char_superscript,
+	&char_subscript,
 };
 
 /* render • structure containing one particular render */
@@ -689,7 +692,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t ma
 static size_t
 char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size)
 {
-	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>/^~";
+	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>/^~%";
 	struct buf work = { 0, 0, 0, 0 };
 
 	if (size > 1) {
@@ -1198,6 +1201,44 @@ char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 	sup = rndr_newbuf(rndr, BUFFER_SPAN);
 	parse_inline(sup, rndr, data + sup_start, sup_len - sup_start);
 	rndr->cb.superscript(ob, sup, rndr->opaque);
+	rndr_popbuf(rndr, BUFFER_SPAN);
+
+	return (sup_start == 2) ? sup_len + 1 : sup_len;
+}
+
+static size_t
+char_subscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t max_rewind, size_t max_lookbehind, size_t size)
+{
+	size_t sup_start, sup_len;
+	struct buf *sup;
+
+	if (!rndr->cb.subscript)
+		return 0;
+
+	if (size < 2)
+		return 0;
+
+	if (data[1] == '(') {
+		sup_start = sup_len = 2;
+
+		while (sup_len < size && data[sup_len] != ')' && data[sup_len - 1] != '\\')
+			sup_len++;
+
+		if (sup_len == size)
+			return 0;
+	} else {
+		sup_start = sup_len = 1;
+
+		while (sup_len < size && !_isspace(data[sup_len]))
+			sup_len++;
+	}
+
+	if (sup_len - sup_start == 0)
+		return (sup_start == 2) ? 3 : 0;
+
+	sup = rndr_newbuf(rndr, BUFFER_SPAN);
+	parse_inline(sup, rndr, data + sup_start, sup_len - sup_start);
+	rndr->cb.subscript(ob, sup, rndr->opaque);
 	rndr_popbuf(rndr, BUFFER_SPAN);
 
 	return (sup_start == 2) ? sup_len + 1 : sup_len;
@@ -2547,6 +2588,9 @@ sd_markdown_new(
 
 	if (extensions & MKDEXT_SUPERSCRIPT)
 		md->active_char['^'] = MD_CHAR_SUPERSCRIPT;
+
+	if (extensions & MKDEXT_SUPERSCRIPT)
+		md->active_char['%'] = MD_CHAR_SUBSCRIPT;
 
 	/* Extension data */
 	md->ext_flags = extensions;

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -90,6 +90,7 @@ struct sd_callbacks {
 	int (*raw_html_tag)(struct buf *ob, const struct buf *tag, void *opaque);
 	int (*triple_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*strikethrough)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*underline)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*superscript)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*subscript)(struct buf *ob, const struct buf *text, void *opaque);
 

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -60,6 +60,7 @@ enum mkd_extensions {
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
 	MKDEXT_NO_EMAIL_AUTOLINK = (1 << 9),
+	MKDEXT_SUBSCRIPT = (1 << 10),
 };
 
 /* sd_callbacks - functions for rendering parsed data */
@@ -90,6 +91,7 @@ struct sd_callbacks {
 	int (*triple_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*strikethrough)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*superscript)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*subscript)(struct buf *ob, const struct buf *text, void *opaque);
 
 	/* low level callbacks - NULL copies input directly into the output */
 	void (*entity)(struct buf *ob, const struct buf *entity, void *opaque);

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -69,6 +69,15 @@ cases = {
     r'Escape\^superscript':
         '<p>Escape^superscript</p>\n',
 
+    r'No%subscript':
+        '<p>Nosubscript</p>\n',
+
+    r'No%(subscript)':
+        '<p>Nosubscript</p>\n',
+
+    r'Escape\%subscript':
+        '<p>Escape%subscript</p>\n',
+
     r'~~normal strikethrough~~':
         '<p><del>normal strikethrough</del></p>\n',
 

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -84,6 +84,12 @@ cases = {
     r'\~~escaped strikethrough~~':
         '<p>~~escaped strikethrough~~</p>\n',
 
+    r'~normal underline~':
+        '<p>normal underline</p>\n',
+
+    r'\~escaped underline~':
+        '<p>~escaped underline~</p>\n',
+
     'anywhere\x03, you':
         '<p>anywhere, you</p>\n',
 


### PR DESCRIPTION
👓 @spladug @JordanMilne 

Per [JIRA CREATE-518](https://reddit.atlassian.net/browse/CREATE-518):

The new rich-text editor enables two additional inline styles: underline and subscript. We've extended our CommonMark parser with the following corresponding syntaxes:

* `~underline~`
* `%(subscript)`
* `%subscript%subscript`

snudown does not provide for either of the two styles. Therefore, in order to preserve compatibility of new content with old clients, we should strip these styles when rendering via snudown.

This PR is mostly copy/paste of existing functionality. It passes the additional tests against the new syntaxes.

Note: in the case of underline, we can alternatively wrap content in `<u>` tags. I haven't elected to do that here as I'm not sure whether we want to begin rendering out a style we've never supported historically, but it's certainly something that can be added very easily.