### PR TITLE
Initialize struct with the correct number of members

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -723,6 +723,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		NULL,
 		NULL,
 		NULL,
+		NULL,
 		toc_header,
 		NULL,
 		NULL,


### PR DESCRIPTION
b5ade1a697b48c7893fbbbde3d708ed9bb111f29 (#78) added two members to this struct, but only one to this initializer.
This leads to undefined behaviour when rendering something like `#/u/test`, since the other callback functions are called through wrongly-typed function pointers.

(It's my understanding that reddit doesn't use Snudown to render the ToC, and hence doesn't test this code path, but I'm surprised that compiler warnings about this were disabled [or ignored?])