### PR TITLE
Enable codefence markdown extension

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -124,7 +124,7 @@ rndr_blockcode(struct buf *ob, const struct buf *text, const struct buf *lang, v
 
 	if (lang && lang->size) {
 		size_t i, cls;
-		BUFPUTSL(ob, "<pre><code class=\"");
+		BUFPUTSL(ob, "<pre><code class=\"md-code-language-");
 
 		for (i = 0, cls = 0; i < lang->size; ++i, ++cls) {
 			while (i < lang->size && isspace(lang->data[i]))

--- a/snudown.c
+++ b/snudown.c
@@ -50,7 +50,8 @@ static const unsigned int snudown_default_md_flags =
 	MKDEXT_SUPERSCRIPT |
 	MKDEXT_AUTOLINK |
 	MKDEXT_STRIKETHROUGH |
-	MKDEXT_TABLES;
+	MKDEXT_TABLES |
+	MKDEXT_FENCED_CODE;
 
 static const unsigned int snudown_default_render_flags =
 	HTML_SKIP_HTML |

--- a/test_snudown.py
+++ b/test_snudown.py
@@ -407,7 +407,13 @@ cases = {
     '>! This is an illegal blockspoiler >!with an inline spoiler!<':
         '<p>&gt;! This is an illegal blockspoiler <span class="md-spoiler-text">with an inline spoiler</span></p>\n',
     'This is an >!inline spoiler with some >!additional!< text!<':
-        '<p>This is an <span class="md-spoiler-text">inline spoiler with some &gt;!additional</span> text!&lt;</p>\n'
+        '<p>This is an <span class="md-spoiler-text">inline spoiler with some &gt;!additional</span> text!&lt;</p>\n',
+
+    # Code fence tests
+    '```\nhello, world!\n```':
+        '<pre><code>hello, world!\n</code></pre>\n',
+    '```javascript\nimport leftpad from "left-pad";\n```':
+        '<pre><code class="md-code-language-javascript">import leftpad from &quot;left-pad&quot;;\n</code></pre>\n',
 }
 
 


### PR DESCRIPTION
This pull request enables the GitHub-style markdown codefences in Snudown (by enabling the `MKDEXT_FENCED_CODE` flag)

So, if merged, code blocks like this will work on the old reddit design:

   \```javascript
    import leftpad from "left-pad";
    ```

This also modifies the generated codeblocks somewhat. Previously, it would have a `<pre>` with a class like this:

```html
<code class="javascript">
```

Where the class is any un-namespaced user-provided css class, which may not be desirable.

I tweaked it to be like this instead:

```html
<code class="md-code-language-javascript">
```

So it is namespaced, but still gives people making stylesheets or someone making a browser extension something to work with for determining the language of the code block.