### PR TITLE
Fix mailto links

### DIFF
--- a/src/autolink.c
+++ b/src/autolink.c
@@ -31,7 +31,7 @@ sd_autolink_issafe(const uint8_t *link, size_t link_len)
 {
 	static const size_t valid_uris_count = 14;
 	static const char *valid_uris[] = {
-		"http://", "https://", "ftp://", "mailto://",
+		"http://", "https://", "ftp://", "mailto:",
 		"/", "git://", "steam://", "irc://", "news://", "mumble://",
 		"ssh://", "ircs://", "ts3server://", "#"
 	};


### PR DESCRIPTION
Replace the `mailto://` scheme with `mailto:`

#67 